### PR TITLE
Bugfix/files paths

### DIFF
--- a/EasySave/EasySave by ProSoft/Models/AppSettings.cs
+++ b/EasySave/EasySave by ProSoft/Models/AppSettings.cs
@@ -10,7 +10,7 @@ namespace EasySave_by_ProSoft.Models
         private static AppSettings? instance;
         private string? configFilePath =
           Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                 "EasySave",
                 "config.json"
             );

--- a/EasySave/EasySave by ProSoft/Models/BackupManager.cs
+++ b/EasySave/EasySave by ProSoft/Models/BackupManager.cs
@@ -20,9 +20,9 @@ namespace EasySave_by_ProSoft.Models
         public BackupManager()
         {
             backupJobs = new List<BackupJob>();
-            // Define the jobs configuration file path in LocalApplicationData/EasySave
+            // Define the jobs configuration file path in ApplicationData/EasySave
             jobsConfigFilePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                 "EasySave",
                 "jobs.json"
             );

--- a/EasySave/EasySave by ProSoft/Models/JobEventManager.cs
+++ b/EasySave/EasySave by ProSoft/Models/JobEventManager.cs
@@ -28,7 +28,7 @@ namespace EasySave_by_ProSoft.Models
         {
             // Define the state.json file location
             stateFilePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                 "EasySave",
                 "state.json"
             );

--- a/EasySave/EasySave by ProSoft/Models/JobStatus.cs
+++ b/EasySave/EasySave by ProSoft/Models/JobStatus.cs
@@ -264,7 +264,7 @@ namespace EasySave_by_ProSoft.Models
             {
                 // Get the state.json file path 
                 string stateFilePath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                     "EasySave",
                     "state.json"
                 );


### PR DESCRIPTION
This pull request updates the file storage path for configuration, job, and state files in the `EasySave` application. The changes ensure that these files are now stored in the `ApplicationData` folder instead of the `LocalApplicationData` folder, aligning with a more centralized storage approach.

### Updates to file storage paths:

* [`EasySave/EasySave by ProSoft/Models/AppSettings.cs`](diffhunk://#diff-b499de260a36515cd125f202c57bd6b0b45b2f56eaa11d4d388ab3f5363dd0a9L13-R13): Changed the `config.json` file path to use `Environment.SpecialFolder.ApplicationData` instead of `LocalApplicationData`.

* [`EasySave/EasySave by ProSoft/Models/BackupManager.cs`](diffhunk://#diff-917539e97949ca7f96b8618bd922e2fdeecdb9bedaa7c0e784c674f4c1fb47e8L23-R25): Updated the `jobs.json` file path to use `Environment.SpecialFolder.ApplicationData` for defining the jobs configuration file location.

* [`EasySave/EasySave by ProSoft/Models/JobEventManager.cs`](diffhunk://#diff-00bef8c70b5391b0aafdd2e538f276931d15db44c71ca08f7f2421fd22ea4568L31-R31): Modified the `state.json` file path to use `Environment.SpecialFolder.ApplicationData` for defining the state file location.

* [`EasySave/EasySave by ProSoft/Models/JobStatus.cs`](diffhunk://#diff-0044e1d24705667f38a2acc6257b2906fa935f816a0d742b4f68ef4f1c636fd1L267-R267): Updated the `state.json` file path in the `LoadStateFromPrevious` method to use `Environment.SpecialFolder.ApplicationData`.