### PR TITLE
Bugfixe/encryption t ime log

### DIFF
--- a/EasySave/EasySave by ProSoft/Models/EncryptionService.cs
+++ b/EasySave/EasySave by ProSoft/Models/EncryptionService.cs
@@ -76,12 +76,12 @@ namespace EasySave_by_ProSoft.Models
                     process.StartInfo.CreateNoWindow = true;
                     process.StartInfo.RedirectStandardOutput = true;
                     process.StartInfo.RedirectStandardError = true;
-
                     process.Start();
-                    process.BeginOutputReadLine();
+
                     long encryptionTime = 0;
+                    string output = process.StandardOutput.ReadToEnd(); // Correct usage of ReadToEnd
                     process.WaitForExit();
-                    string output = process.StandardOutput.ReadToEnd();
+
                     encryptionTime = long.Parse(output.Trim());
 
                     // Check exit code

--- a/EasySave/EasySave by ProSoft/ViewModels/SettingsViewModel.cs
+++ b/EasySave/EasySave by ProSoft/ViewModels/SettingsViewModel.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 
 namespace EasySave_by_ProSoft.ViewModels
@@ -94,8 +95,11 @@ namespace EasySave_by_ProSoft.ViewModels
 
         }
 
-
-
+        public string EncryptionKey
+        {
+            get => _settings.GetSetting("EncryptionKey")?.ToString() ?? string.Empty;
+            set { _settings.SetSetting("EncryptionKey", value); OnPropertyChanged(); SaveSettings(); }
+        }
 
         public string LogFormat
         {

--- a/EasySave/EasySave by ProSoft/Views/SettingsView.xaml
+++ b/EasySave/EasySave by ProSoft/Views/SettingsView.xaml
@@ -49,7 +49,7 @@
             <TextBox x:Name="BusinessSoftwareProcessNameTextBox" ToolTip="Ex: calc.exe" Margin="0,0,0,10" Text="{Binding BusinessSoftwareName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
             <TextBlock Text="Clé de chiffrement :" VerticalAlignment="Center" Margin="0,0,5,0"/>
-            <PasswordBox x:Name="EncryptionKeyBox" Margin="0,0,0,10" Width="200" />
+            <PasswordBox x:Name="EncryptionKeyBox" Margin="0,0,0,10" Width="200" PasswordChanged="EncryptionKeyBox_PasswordChanged"/>
 
             <TextBlock Text="{x:Static localization:Resources.LogFileFormatSetting}" Margin="0,0,0,5" />
             <ComboBox x:Name="LogFormatComboBox" Margin="0,0,0,20" Text="{Binding LogFormat, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">

--- a/EasySave/EasySave by ProSoft/Views/SettingsView.xaml.cs
+++ b/EasySave/EasySave by ProSoft/Views/SettingsView.xaml.cs
@@ -34,6 +34,16 @@ namespace EasySave_by_ProSoft.Views
                 EncryptionKeyBox.Password = savedKey;
             }
 
+            // Synchronize PasswordBox with ViewModel if EncryptionKey changes in ViewModel
+            _settingsViewModel.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(SettingsViewModel.EncryptionKey))
+                {
+                    if (EncryptionKeyBox.Password != _settingsViewModel.EncryptionKey)
+                        EncryptionKeyBox.Password = _settingsViewModel.EncryptionKey;
+                }
+            };
+
             // Initialize the log format ComboBox
             if (LogFormatComboBox != null)
             {
@@ -118,6 +128,16 @@ namespace EasySave_by_ProSoft.Views
 
                 Settings.Default.UserLanguage = _initialCultureName;
                 Settings.Default.Save();
+            }
+        }
+
+        // Add this event handler to synchronize PasswordBox with ViewModel
+        private void EncryptionKeyBox_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is SettingsViewModel vm)
+            {
+                if (EncryptionKeyBox.Password != vm.EncryptionKey)
+                    vm.EncryptionKey = EncryptionKeyBox.Password;
             }
         }
     }


### PR DESCRIPTION
This pull request introduces improvements to the encryption workflow and settings management in the `EasySave` application. Key changes include refactoring encryption logic for better clarity and error handling, adding synchronization between the encryption key UI and the ViewModel, and updating the encryption process to correctly handle output. 

### Encryption Workflow Improvements:
* Refactored `_totalEncryptionTime` to `_encryptionTime` in `BackupJob` for clarity and updated its usage to reflect the time for the current encryption operation only. (`BackupJob.cs`, [EasySave/EasySave by ProSoft/Models/BackupJob.csL26-R27](diffhunk://#diff-378919214ecdffdfb14c320bd9d0dcdbefb8bc644f6a78ade523ba91b1d7ad5dL26-R27))
* Improved the logic for handling encryption extensions and encryption keys in `ProcessFiles`. Added checks for null or empty encryption keys and displayed warnings when necessary. (`BackupJob.cs`, [EasySave/EasySave by ProSoft/Models/BackupJob.csL208-R239](diffhunk://#diff-378919214ecdffdfb14c320bd9d0dcdbefb8bc644f6a78ade523ba91b1d7ad5dL208-R239))
* Corrected the usage of `ReadToEnd` in the `EncryptFile` method of `EncryptionService` to properly capture the encryption time output. (`EncryptionService.cs`, [EasySave/EasySave by ProSoft/Models/EncryptionService.csL79-R84](diffhunk://#diff-a19365b2c659bfaec95b0fcb048f2d7205140ad17e3fc5a5937f09dda4334a3fL79-R84))

### Settings Management Enhancements:
* Added a new `EncryptionKey` property in the `SettingsViewModel` to enable two-way binding and automatic updates to the encryption key in the UI. (`SettingsViewModel.cs`, [EasySave/EasySave by ProSoft/ViewModels/SettingsViewModel.csL97-R102](diffhunk://#diff-47d3ca2781a6c019906b92414b582b34bcb242d629c302703a699547eed223b4L97-R102))
* Updated the `SettingsView` to synchronize the `PasswordBox` with the `EncryptionKey` property in the ViewModel, ensuring the UI reflects changes in real time. (`SettingsView.xaml`, [[1]](diffhunk://#diff-41a72331db522f5926576a8365f2d9b4437027482452e55d6bc49ea05857a4c2L52-R52); `SettingsView.xaml.cs`, [[2]](diffhunk://#diff-c7c0555ba5d28ef678d9a2bfaccef3cf9fd4e6670a097822a6c8c864af357c70R37-R46) [[3]](diffhunk://#diff-c7c0555ba5d28ef678d9a2bfaccef3cf9fd4e6670a097822a6c8c864af357c70R133-R142)