### PR TITLE
Feature/max file

### DIFF
--- a/EasySave/EasySave by ProSoft/App.xaml.cs
+++ b/EasySave/EasySave by ProSoft/App.xaml.cs
@@ -2,15 +2,31 @@
 using EasySave_by_ProSoft.Properties; // For Settings.Default
 using System.Globalization;
 using System.Windows;
+using System.Threading;
+
 
 namespace EasySave_by_ProSoft
 {
     public partial class App : System.Windows.Application
     {
         private const string DefaultCultureName = "en-US"; // Default language if nothing is saved or if error
+        private static Mutex? _mutex;
+        private const string MutexName = "EasySave_by_ProSoft_SingleInstanceMutex";
+
 
         protected override void OnStartup(StartupEventArgs e)
         {
+            bool createdNew;
+            _mutex = new Mutex(true, MutexName, out createdNew);
+
+            if (!createdNew)
+            {
+                // Une autre instance est déjà en cours d'exécution
+                System.Windows.MessageBox.Show("L'application est déjà en cours d'exécution.", "Instance unique", MessageBoxButton.OK, MessageBoxImage.Information);
+                Shutdown();
+                return;
+            }
+
             string initialThreadCultureName = Thread.CurrentThread.CurrentUICulture.Name;
             string initialSavedLang = Settings.Default.UserLanguage;
 
@@ -26,26 +42,27 @@ namespace EasySave_by_ProSoft
                 }
                 catch (CultureNotFoundException)
                 {
-                    // The saved language is invalid, use the default language and save it
-                    System.Windows.MessageBox.Show($"App.OnStartup: Culture '{savedLang}' not found. Switching to default language '{DefaultCultureName}'.", "Debug Startup - Invalid Culture");
+                    // La langue sauvegardée est invalide, on utilise la langue par défaut et on la sauvegarde
+                    System.Windows.MessageBox.Show($"App.OnStartup: Culture '{savedLang}' non trouvée. Passage à la langue par défaut '{DefaultCultureName}'.", "Debug Startup - Culture invalide");
                     targetCulture = new CultureInfo(DefaultCultureName);
                     Settings.Default.UserLanguage = DefaultCultureName;
-                    Settings.Default.Save(); // Save default language
+                    Settings.Default.Save(); // Sauvegarde de la langue par défaut
                 }
             }
             else
             {
-                // No language saved (first launch), use default language and save it
-                System.Windows.MessageBox.Show($"App.OnStartup: No language saved. Switching to default language '{DefaultCultureName}'.", "Debug Startup - No Language Saved");
+                // Aucune langue sauvegardée (premier lancement), on utilise la langue par défaut et on la sauvegarde
+                System.Windows.MessageBox.Show($"App.OnStartup: Aucune langue sauvegardée. Passage à la langue par défaut '{DefaultCultureName}'.", "Debug Startup - Aucune langue sauvegardée");
                 targetCulture = new CultureInfo(DefaultCultureName);
                 Settings.Default.UserLanguage = DefaultCultureName;
-                Settings.Default.Save(); // Save default language
+                Settings.Default.Save(); // Sauvegarde de la langue par défaut
             }
 
             ApplyCulture(targetCulture);
 
             base.OnStartup(e);
         }
+
 
         private void ApplyCulture(CultureInfo culture)
         {
@@ -58,5 +75,15 @@ namespace EasySave_by_ProSoft
                 Localization.Resources.Culture = culture;
             }
         }
+
+        /// <summary>
+        /// Handles the application exit event to release the mutex.
+        protected override void OnExit(ExitEventArgs e)
+        {
+            _mutex?.ReleaseMutex();
+            _mutex?.Dispose();
+            base.OnExit(e);
+        }
+
     }
 }

--- a/EasySave/EasySave by ProSoft/App.xaml.cs
+++ b/EasySave/EasySave by ProSoft/App.xaml.cs
@@ -21,7 +21,7 @@ namespace EasySave_by_ProSoft
 
             if (!createdNew)
             {
-                // Une autre instance est déjà en cours d'exécution
+                // Another instance is already running, show a message and exit
                 System.Windows.MessageBox.Show("L'application est déjà en cours d'exécution.", "Instance unique", MessageBoxButton.OK, MessageBoxImage.Information);
                 Shutdown();
                 return;
@@ -42,20 +42,20 @@ namespace EasySave_by_ProSoft
                 }
                 catch (CultureNotFoundException)
                 {
-                    // La langue sauvegardée est invalide, on utilise la langue par défaut et on la sauvegarde
+                    //The saved language is not valid, fallback to default language
                     System.Windows.MessageBox.Show($"App.OnStartup: Culture '{savedLang}' non trouvée. Passage à la langue par défaut '{DefaultCultureName}'.", "Debug Startup - Culture invalide");
                     targetCulture = new CultureInfo(DefaultCultureName);
                     Settings.Default.UserLanguage = DefaultCultureName;
-                    Settings.Default.Save(); // Sauvegarde de la langue par défaut
+                    Settings.Default.Save(); // Save the default language
                 }
             }
             else
             {
-                // Aucune langue sauvegardée (premier lancement), on utilise la langue par défaut et on la sauvegarde
+                // Any saved language is empty, use the default language and save it
                 System.Windows.MessageBox.Show($"App.OnStartup: Aucune langue sauvegardée. Passage à la langue par défaut '{DefaultCultureName}'.", "Debug Startup - Aucune langue sauvegardée");
                 targetCulture = new CultureInfo(DefaultCultureName);
                 Settings.Default.UserLanguage = DefaultCultureName;
-                Settings.Default.Save(); // Sauvegarde de la langue par défaut
+                Settings.Default.Save(); // Save the default language
             }
 
             ApplyCulture(targetCulture);

--- a/EasySave/EasySave by ProSoft/Models/BackupJob.cs
+++ b/EasySave/EasySave by ProSoft/Models/BackupJob.cs
@@ -221,19 +221,23 @@ namespace EasySave_by_ProSoft.Models
 
         if (!isPriority && _backupManager != null && _backupManager.HasPendingPriorityFiles())
         {
+             /*
             // Ignorer temporairement les fichiers non prioritaires
             System.Windows.Forms.MessageBox.Show(
                 $"[IGNORÉ] {sourceFile} (non prioritaire)\nDes fichiers prioritaires restent à traiter.",
                 "Ordre de traitement", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Information);
+             */
             ignoredNonPriority.Add(sourceFile);
             continue;
         }
         else
         {
+                    /*
             string message = isPriority ? "[PRIORITAIRE]" : "[NORMAL]";
             System.Windows.Forms.MessageBox.Show(
                 $"{message} {sourceFile} est traité.",
                 "Ordre de traitement", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Information);
+                    */
         }
 
         await ProcessSingleFile(sourceFile, largeFileSizeThresholdBytes);
@@ -247,15 +251,18 @@ namespace EasySave_by_ProSoft.Models
 
         if (_backupManager != null && _backupManager.HasPendingPriorityFiles())
         {
+                    /*
             System.Windows.Forms.MessageBox.Show(
                 $"[ATTENTE] {sourceFile} (non prioritaire) attend toujours la fin des prioritaires.",
                 "Ordre de traitement", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Information);
+                    */
             continue;
         }
-
+        /*
         System.Windows.Forms.MessageBox.Show(
             $"[NORMAL] {sourceFile} est finalement traité (après les prioritaires).",
             "Ordre de traitement", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Information);
+        */
 
         await ProcessSingleFile(sourceFile, largeFileSizeThresholdBytes);
         this.toProcessFiles.Remove(sourceFile);

--- a/EasySave/EasySave by ProSoft/Models/BackupJob.cs
+++ b/EasySave/EasySave by ProSoft/Models/BackupJob.cs
@@ -219,26 +219,14 @@ namespace EasySave_by_ProSoft.Models
                 string ext = Path.GetExtension(sourceFile);
                 bool isPriority = PriorityExtensionManager.IsPriorityExtension(ext);
 
-                /*
-                System.Windows.Forms.MessageBox.Show(
-                    $"Fichier : {Path.GetFileName(sourceFile)}\nExtension : {ext}\nPrioritaire : {(isPriority ? "OUI" : "NON")}",
-                    "Test Priorité (1ère passe)",
-                    System.Windows.Forms.MessageBoxButtons.OK,
-                    isPriority ? System.Windows.Forms.MessageBoxIcon.Information : System.Windows.Forms.MessageBoxIcon.None
-              
-                );
-                  */
+
 
                 if (!isPriority && _backupManager != null && _backupManager.HasAnyPendingPriorityFiles())
                 {
-                    /*
-                    System.Windows.Forms.MessageBox.Show(
-                        $"[IGNORÉ] {sourceFile} (non prioritaire)\nDes fichiers prioritaires restent à traiter dans une autre sauvegarde.",
-                        "Barrière Priorité Globale", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Warning);
                     ignoredNonPriority.Add(sourceFile);
-                    */
                     continue;
                 }
+
 
                 await ProcessLargeFileWithSemaphore(sourceFile, largeFileSizeThresholdBytes);
                 this.toProcessFiles.Remove(sourceFile);
@@ -246,11 +234,7 @@ namespace EasySave_by_ProSoft.Models
 
        
             if (ignoredNonPriority.Count > 0)
-            {/*
-                System.Windows.Forms.MessageBox.Show(
-                    "Attente de la fin de tous les fichiers prioritaires (barrière globale)...",
-                    "Barrière Priorité Globale", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Information);
-            */
+            {
                 }
 
             // Barrier to wait for all priority files to finish processing
@@ -270,11 +254,7 @@ namespace EasySave_by_ProSoft.Models
                 }
                 if (_stopRequested) break;
 
-                /*
-                System.Windows.Forms.MessageBox.Show(
-                    $"[NON PRIORITAIRE] {Path.GetFileName(sourceFile)} est finalement traité (après la barrière).",
-                    "Test Non Prioritaire (2ème passe)", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Information);
-                */
+               
                 await ProcessLargeFileWithSemaphore(sourceFile, largeFileSizeThresholdBytes);
                 this.toProcessFiles.Remove(sourceFile);
             }
@@ -457,11 +437,7 @@ namespace EasySave_by_ProSoft.Models
             if (fileSize > largeFileSizeThresholdBytes)
             {
                 double thresholdKB = largeFileSizeThresholdBytes / 1024.0;
-                System.Windows.Forms.MessageBox.Show(
-                    $"Fichier volumineux détecté : {Path.GetFileName(sourceFile)}\nTaille : {fileSize / 1024} Ko (Seuil : {thresholdKB} Ko).\nAttente du sémaphore.",
-                    "Debug Fichier Volumineux",
-                    System.Windows.Forms.MessageBoxButtons.OK,
-                    System.Windows.Forms.MessageBoxIcon.Information);
+                
 
                 await _largeFileTransferSemaphore.WaitAsync();
                 try


### PR DESCRIPTION
This pull request introduces several enhancements to the `EasySave` application, focusing on improving single-instance enforcement, handling of large file transfers, and priority file processing. Additionally, it includes minor refactoring and translation updates for better maintainability and usability.

### Application Behavior Enhancements:
* **Single-Instance Enforcement**: Introduced a `Mutex` in `App.xaml.cs` to ensure only one instance of the application can run at a time. If another instance is detected, the application displays a message and exits. (`[EasySave/EasySave by ProSoft/App.xaml.csR5-R29](diffhunk://#diff-e3b4aa7a859a53fe094f93eebaef8c8868b2c7d69afaed94abfa5270437db86dR5-R29)`)
* **Graceful Mutex Release**: Added an `OnExit` override to release and dispose of the mutex when the application exits. (`[EasySave/EasySave by ProSoft/App.xaml.csR78-R87](diffhunk://#diff-e3b4aa7a859a53fe094f93eebaef8c8868b2c7d69afaed94abfa5270437db86dR78-R87)`)

### Backup Process Improvements:
* **Large File Handling**: Added a new method, `ProcessLargeFileWithSemaphore`, in `BackupJob.cs` to manage large file transfers using a semaphore, ensuring controlled parallelism for large files. (`[EasySave/EasySave by ProSoft/Models/BackupJob.csR454-R481](diffhunk://#diff-378919214ecdffdfb14c320bd9d0dcdbefb8bc644f6a78ade523ba91b1d7ad5dR454-R481)`)
* **Priority File Barrier**: Enhanced the `ProcessFiles` method in `BackupJob.cs` to implement a barrier mechanism that ensures priority files are processed before non-priority files. This includes waiting for all priority files to finish before proceeding with non-priority ones. (`[EasySave/EasySave by ProSoft/Models/BackupJob.csL222-R282](diffhunk://#diff-378919214ecdffdfb14c320bd9d0dcdbefb8bc644f6a78ade523ba91b1d7ad5dL222-R282)`)

### Codebase Refinements:
* **Priority File Check Refactoring**: Replaced the `HasPendingPriorityFiles` method with `HasAnyPendingPriorityFiles` in `BackupManager.cs` for a more efficient and thread-safe implementation using a lock. (`[EasySave/EasySave by ProSoft/Models/BackupManager.csL276-L302](diffhunk://#diff-917539e97949ca7f96b8618bd922e2fdeecdb9bedaa7c0e784c674f4c1fb47e8L276-L302)`)
* **Translation Updates**: Updated debug messages in `App.xaml.cs` to use French, aligning with localized application behavior. (`[EasySave/EasySave by ProSoft/App.xaml.csL29-R66](diffhunk://#diff-e3b4aa7a859a53fe094f93eebaef8c8868b2c7d69afaed94abfa5270437db86dL29-R66)`)